### PR TITLE
Fixed repository title overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -172,6 +172,10 @@ a:hover, a:focus, a:active, a:visited {
     color: #016cc7;
 }
 
+.repos > h3 {
+    overflow-wrap: break-word;
+}
+
 .speaker .repos {
     width: 31.333333%;
     -webkit-transition: all 0.3s;


### PR DESCRIPTION
Fixes #1 

This commits adds `overflow-wrap: break-word` to all the `<H3>` tags

Screenshot:
![image](https://user-images.githubusercontent.com/30751793/70532227-9ea92000-1b7c-11ea-9aee-46b2c3c08d21.png)


Signed-off-by: Devil <bhumijgupta@gmail.com>